### PR TITLE
fix(useDebug): add empty array to skip unmounted being logged on re-renders

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const useDebug = id => {
     return () => {
       console.log(`__DEBUG_${id}__ unmounted`)
     }
-  })
+  }, [])
 }
 
 export default useDebug


### PR DESCRIPTION
Since this hook was basically to debug when your component gets mounted/unmounted we should skip the effect being called on re-renders. I don't know if that was the main moto of this hook 🙈 